### PR TITLE
Added support for custom decorators, made it work with deno_reflect scopes drop-in. Updated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ NestJS-style decorators library for Deno's [oak](https://github.com/oakserver/oa
 - **Decorators**: Configure route endpoint methods in a declarative style.
 - **Controller Support**: Define your routes in a declarative way using controllers.
 - **Custom Middleware Support**: Create middleware decorators to control access and flow to routes
+- **Custom Middleware Params Support**: Create endpoint parameters decorators for parameter injection
 
 ## Important
 
@@ -288,4 +289,34 @@ export default class SampleController {
     // Logic to get all users
   }
 }
+```
+
+### Custom endpoint parameters decorator
+
+It's also possible to register custom parameters decorators to streamline data injection into endpoint handlers
+
+It would be useful to have a shortcut to some data stored in the request's JWT.
+
+The approach would involve having a high priority controller that parses the JWT and stores it in `context.state.jwtData`.
+
+Then a param decorator could be defined as follows: 
+
+```typescript
+export function JWT(propName? : string) {
+  return function(targetClass: any, methodName: string, paramIndex: number) {
+    const handler = (ctx : Context) => 
+      propName ? ctx.state.jwtData?.[propName] : ctx.state.jwtData;
+    registerCustomRouteParamDecorator(targetClass, methodName, paramIndex)(handler);
+  }
+}
+```
+
+```typescript
+//sample-controller
+
+@Get('my-subscriptions')
+getUserSubscriptions(@JWT('sub') userId : string) {
+  return await databaseService.getUserSubscriptions(userId);
+}
+
 ```

--- a/README.md
+++ b/README.md
@@ -1,16 +1,82 @@
-# oak decorators
+# Oak Decorators
 
-Project implements decorators like implementation of [Nest.js](https://nestjs.com/) for Deno's web framework [oak](https://github.com/oakserver/oak).
+NestJS-style decorators library for Deno's [oak](https://github.com/oakserver/oak).
+
+## TL;DR Key features:
+
+- **Dependency Injection**: Simplify your code and testing process by injecting dependencies.
+- **Modular Structure**: Organize your code into modules for better scalability and maintainability.
+- **Decorators**: Configure route endpoint methods in a declarative style.
+- **Controller Support**: Define your routes in a declarative way using controllers.
+- **Custom Middleware Support**: Create middleware decorators to control access and flow to routes
+
+## Important
+
+Due to the incompatibility of reflect_metadata exports in Deno, in order for this library to work it's important to add the deno_reflect drop-in replacement in your project's scopes like this:
+
+```jsonc
+// deno.json
+{
+  //...
+  "scopes": {
+    "https://deno.land/x/": {
+      "https://deno.land/x/reflect_metadata@v0.1.12-2/mod.ts": "https://deno.land/x/deno_reflect@v0.2.1/mod.ts"
+    }
+  }
+  //...
+}
+```
+
+For more info [check this issue](https://github.com/denoland/deno/issues/15197)
 
 ## Usage
 
-The following are the core files that need to be created in the first step.
+Define controllers to handle HTTP endpoints
+
+```typescript
+// ./controllers/util-controller.ts
+import {
+  Controller,
+  Get,
+  Headers,
+} from 'https://deno.land/x/oak_decorators/mod.ts';
+
+@Controller('util')
+export class UtilController {
+  @Get('user-agent')
+  bounceUserAgent(@Headers('user-agent') userAgent: string) {
+    return { status: 'ok', userAgent };
+  }
+
+  @Get('multiply')
+  getRandomStuff(@Query('f1') factor1: number, @Query('f2') factor2: number) {
+    return { status: 'ok', result: factor1 * factor2 };
+  }
+}
+```
+
+Define modules
+
+```typescript
+// ./app.module.ts
+import { Module } from 'https://deno.land/x/oak_decorators/mod.ts';
+import { UtilController } from './app.controller.ts';
+
+@Module({
+  controllers: [UtilController],
+  routePrefix: 'api/v1',
+  modules: [], //optional submodules
+})
+export class AppModule {}
+```
+
+Register an app module with oak.
 
 ```typescript
 // ./main.ts
-import { Application } from "https://deno.land/x/oak/mod.ts";
-import { assignModule } from "https://deno.land/x/oak_decorators/mod.ts";
-import { AppModule } from "./app.module.ts";
+import { Application } from 'https://deno.land/x/oak/mod.ts';
+import { assignModule } from 'https://deno.land/x/oak_decorators/mod.ts';
+import { AppModule } from './app.module.ts';
 
 const app = new Application();
 app.use(assignModule(AppModule));
@@ -18,38 +84,10 @@ app.use(assignModule(AppModule));
 await app.listen({ port: 8000 });
 ```
 
-```typescript
-// ./app.module.ts
-import { Module } from "https://deno.land/x/oak_decorators/mod.ts";
-import { AppController } from "./app.controller.ts";
+Run your app and following endpoints will be available:
 
-@Module({
-  controllers: [AppController],
-  routePrefix: "v1",
-})
-export class AppModule {}
-```
-
-```typescript
-// ./app.controller.ts
-import { Controller, Get, Headers } from "https://deno.land/x/oak_decorators/mod.ts";
-
-@Controller()
-export class AppController {
-  @Get()
-  get(@Headers("user-agent") userAgent: string) {
-    return { status: "ok", userAgent };
-  }
-}
-```
-
-Here's a brief overview of those core files:
-
-| name | description |
-|:-|:-|
-| `app.module.ts` | The root module of the application. |
-| `app.controller.ts` | A basic controller with a single route. |
-| `main.ts` | The entry file of the application which uses the core middleware assignModule to use decorations. |
+- `/api/v1/util/user-agent`
+- `/api/v1/util/multiply?f1=2&f2=4`
 
 ## Docs
 
@@ -60,22 +98,22 @@ Each application has at least one module, a root module, and each modules can ha
 
 The `@Module()` decorator takes those options:
 
-|name|description|
-|:-|:-|
+| name          | description                                                                 |
+| :------------ | :-------------------------------------------------------------------------- |
 | `controllers` | the set of controllers defined in this module which have to be instantiated |
-| `providers` | the providers that will be instantiated by the injector |
-| `modules` | the set of modules defined as child modules of this module |
-| `routePrefix` | the prefix name to be set in route as the common ULR for controllers. |
+| `providers`   | the providers that will be instantiated by the injector                     |
+| `modules`     | the set of modules defined as child modules of this module                  |
+| `routePrefix` | the prefix name to be set in route as the common ULR for controllers.       |
 
 ```typescript
-import { Module } from "https://deno.land/x/oak_decorators/mod.ts";
-import { AppController } from "./app.controller.ts";
-import { SampleModule } from "./sample/sample.module.ts";
+import { Module } from 'https://deno.land/x/oak_decorators/mod.ts';
+import { AppController } from './app.controller.ts';
+import { SampleModule } from './sample/sample.module.ts';
 
 @Module({
   modules: [SampleModule],
   controllers: [AppController],
-  routePrefix: "v1",
+  routePrefix: 'v1',
 })
 export class AppModule {}
 ```
@@ -88,21 +126,20 @@ A controller is a class annotated with a `@Controller()` decorator. Controllers 
 The `@Controller()` decorator take a route path prefix optionally.
 
 ```typescript
-import { Controller, Get } from "https://deno.land/x/oak_decorators/mod.ts";
+import { Controller, Get } from 'https://deno.land/x/oak_decorators/mod.ts';
 
 @Controller('sample')
-export class SampleController {
+export class UsersController {
   @Get()
   findAll(): string {
     return 'OK';
   }
 }
-
 ```
 
 The `@Get()` HTTP request method decorator before the `findAll()` method tells the application to create a handler for a specific endpoint for HTTP requests.
 
-For http methods, you can use `@Get()`, `@Post()`, `@Put()`, `@Patch()`, `@Delete()`.
+For http methods, you can use `@Get()`, `@Post()`, `@Put()`, `@Patch()`, `@Delete()`, `@All()`.
 
 #### Request object
 
@@ -110,7 +147,11 @@ Handlers often need access to the client request details.
 HHere's a example to access the request object using `@Req()` decorator.
 
 ```typescript
-import { Controller, Get, Req } from "https://deno.land/x/oak_decorators/mod.ts";
+import {
+  Controller,
+  Get,
+  Request,
+} from 'https://deno.land/x/oak_decorators/mod.ts';
 
 @Controller('sample')
 export class SampleController {
@@ -119,13 +160,13 @@ export class SampleController {
     return 'OK';
   }
 }
-
 ```
 
 Below is a list of the provided decorators.
 
-|name|
-|:-|
+| name |
+| :--- |
+
 | `@Request()`
 | `@Response()`
 | `@Next()`
@@ -134,49 +175,117 @@ Below is a list of the provided decorators.
 | `@Body(key?: string)`
 | `@Headers(name?: string)`
 | `@Ip()`
+| `@Context()`
 
 ### Providers
 
 Providers are responsible for main business logic as services, repositories, factories, helpers, and so on.  
-The main idea of a provider is that it can be injected as dependency.
+The main idea of a provider is that it can be injected as a dependency. Depending on the environment, different implementations of a service can be provided.
 
 ```typescript
 // ./sample.service.ts
-import { Injectable } from "https://deno.land/x/oak_decorators/mod.ts";
+import { Injectable } from 'https://deno.land/x/oak_decorators/mod.ts';
+import db from './db-service.ts';
 
 @Injectable()
-export class SampleService {
-  get() {
-    return { status: "ok" };
+export class UserService {
+  async getAllUsers() {
+    const { error, data: users } = await db.users.getAll();
+    return { status: 'ok', data: users };
   }
 }
+
+@Injectable()
+export class MockUserService {
+  getAllUsers() {
+    return {
+      status: 'ok',
+      data: [
+        {
+          name: 'John Doe',
+        },
+        {
+          name: 'Jane Doe',
+        },
+      ],
+    };
+  }
+}
+
+// ./sample.controller.ts
+import { Controller, Get } from 'https://deno.land/x/oak_decorators/mod.ts';
+import { UserService } from './sample.service.ts';
+
+@Controller('users')
+export class UsersController {
+  constructor(private readonly userService: UserService) {}
+
+  @Get()
+  getAllUsers() {
+    return await this.userService.getAllUsers();
+  }
+}
+
+// ./sample.module.ts
+import { Module } from 'https://deno.land/x/oak_decorators/mod.ts';
+import { UsersController } from './sample.controller.ts';
+import { UserService, MockUserService } from './sample.service.ts';
+
+@Module({
+  controllers: [UsersController],
+  providers: [
+    Deno.env.get('DENO_ENV') === 'production' ? UserService : MockUserService,
+  ],
+})
+export class SampleModule {}
 ```
+
+### Custom Middleware Decorators
+
+It's possible to register middleware that can be used in controllers by means of decorators.
+
+For instance, to protect routes based on user roles, you can create a `@RequiresRole` middleware decorator.
+
+```typescript
+// ./middleware.ts
+import { registerMiddlewareMethodDecorator } from 'https://deno.land/x/oak_decorators/mod.ts';
+import { Context } from 'https://deno.land/x/oak/mod.ts';
+
+function checkUserRoles(context: Context, roles: string[]) {
+  // Logic to check the user role
+  return false;
+}
+
+export function RequiresRole(roles: string[]) {
+  return function (target, methodName) {
+    const requiresRole = async (context, next) => {
+      // Logic to check the user session or JWT for the required role
+      if (checkUserRoles(context, roles)) {
+        await next();
+      } else {
+        // handle unauthorized access
+        context.response.status = 401;
+        context.response.body = { error: 'Unauthorized' };
+        return;
+      }
+    };
+    registerMiddlewareMethodDecorator(target, methodName, requiresRole);
+  };
+}
+```
+
+Then you can use the `@RequiresRole` decorator in your controllers's methods.
 
 ```typescript
 // ./sample.controller.ts
-import { Controller, Get } from "https://deno.land/x/oak_decorators/mod.ts";
-import { SampleService } from "./sample.service.ts";
+import RequireRole from './middleware.ts';
 
-@Controller('sample')
-export class SampleController {
-  constructor(private readonly sampleService: SampleService) {}
-
-  @Get()
-  get() {
-    return this.sampleService.get();
+@Controller('users')
+export default class SampleController {
+  @Get('/')
+  @RequiresRole(['admin'])
+  getAllUsers() {
+    // Logic to get all users
   }
 }
-```
-
-```typescript
-// ./sample.module.ts
-import { Module } from "https://deno.land/x/oak_decorators/mod.ts";
-import { SampleController } from "./sample.controller.ts";
-import { SampleService } from "./sample.service.ts";
-
-@Module({
-  controllers: [SampleController],
-  providers: [SampleService],
-})
-export class SampleModule {}
 ```

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,4 +1,6 @@
 export const METHOD_METADATA = Symbol('method');
 export const ROUTE_ARGS_METADATA = Symbol('routeArgs');
 export const MODULE_METADATA = Symbol('module');
+export const CONTROLLER_METADATA = Symbol('controller');
 export const MIDDLEWARE_METADATA = Symbol('middleware');
+export const INJECTOR_INTERFACES_METADATA = Symbol('injectorInterfaces');

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,3 +1,4 @@
-export const METHOD_METADATA = Symbol("method");
-export const ROUTE_ARGS_METADATA = Symbol("routeArgs");
-export const MODULE_METADATA = Symbol("module");
+export const METHOD_METADATA = Symbol('method');
+export const ROUTE_ARGS_METADATA = Symbol('routeArgs');
+export const MODULE_METADATA = Symbol('module');
+export const MIDDLEWARE_METADATA = Symbol('middleware');

--- a/src/decorators/controller.decorator.ts
+++ b/src/decorators/controller.decorator.ts
@@ -38,7 +38,7 @@ export function Controller<T extends { new (...instance: any[]): Object }>(
                   .sort((a, b) => a.index - b.index)
                   .map(async (data) => getContextData(data, context, next))
               );
-              context.response.body = (this as any)[meta.functionName](
+              context.response.body = await (this as any)[meta.functionName](
                 ...inputs
               );
             }

--- a/src/decorators/controller.decorator.ts
+++ b/src/decorators/controller.decorator.ts
@@ -1,13 +1,13 @@
 // deno-lint-ignore-file no-explicit-any
-import { Reflect, Router, RouterContext, helpers } from '../deps.ts';
-
-import { ActionMetadata, RouteArgsMetadata } from '../interfaces/mod.ts';
-import { RouteParamtypes } from '../enums/mod.ts';
+import { Reflect, Router, RouterContext, helpers } from "../deps.ts";
+import logger from "../utils/logger.ts";
+import { ActionMetadata, RouteArgsMetadata } from "../interfaces/mod.ts";
+import { RouteParamtypes } from "../enums/mod.ts";
 import {
   METHOD_METADATA,
   MIDDLEWARE_METADATA,
   ROUTE_ARGS_METADATA,
-} from '../const.ts';
+} from "../const.ts";
 
 type Next = () => Promise<unknown>;
 
@@ -20,8 +20,8 @@ export function Controller<T extends { new (...instance: any[]): Object }>(
       private _route?: Router;
 
       init(routePrefix?: string) {
-        const prefix = routePrefix ? `/${routePrefix}` : '';
-        this._path = prefix + (path ? `/${path}` : '');
+        const prefix = routePrefix ? `/${routePrefix}` : "";
+        this._path = prefix + (path ? `/${path}` : "");
         const route = new Router();
         const list: ActionMetadata[] =
           Reflect.getMetadata(METHOD_METADATA, fn.prototype) || [];
@@ -60,13 +60,13 @@ export function Controller<T extends { new (...instance: any[]): Object }>(
               if (context.response.writable) {
                 context.response.body = result;
               } else {
-                console.warn(`Response is not writable`);
+                logger.warn(`Response is not writable`);
               }
             }
           );
 
-          const fullPath = this.path + (meta.path ? `/${meta.path}` : '');
-          console.log(`Mapped: [${meta.method.toUpperCase()}]${fullPath}`);
+          const fullPath = this.path + (meta.path ? `/${meta.path}` : "");
+          logger.info(`Mapped: [${meta.method.toUpperCase()}]${fullPath}`);
         });
 
         this._route = route;

--- a/src/decorators/controller.decorator.ts
+++ b/src/decorators/controller.decorator.ts
@@ -17,12 +17,12 @@ export function Controller<T extends { new (...instance: any[]): Object }>(
     | string
     | {
         path?: string;
-        injectables: string[];
+        injectables: Array<string | symbol | null>;
       }
 ) {
   const path: string | undefined =
     typeof options === 'string' ? options : options?.path;
-  const injectables: string[] | undefined =
+  const injectables =
     typeof options === 'string' ? [] : options?.injectables || [];
 
   return (fn: T): any => {

--- a/src/decorators/controller.decorator.ts
+++ b/src/decorators/controller.decorator.ts
@@ -38,9 +38,14 @@ export function Controller<T extends { new (...instance: any[]): Object }>(
                   .sort((a, b) => a.index - b.index)
                   .map(async (data) => getContextData(data, context, next))
               );
-              context.response.body = await (this as any)[meta.functionName](
-                ...inputs
-              );
+              const result = await (this as any)[meta.functionName](...inputs);
+              if (result === undefined) return;
+
+              if (context.response.writable) {
+                context.response.body = result;
+              } else {
+                console.warn(`Response is not writable`);
+              }
             }
           );
 

--- a/src/decorators/controller.decorator.ts
+++ b/src/decorators/controller.decorator.ts
@@ -123,6 +123,9 @@ async function getContextData(
     case RouteParamtypes.IP: {
       return req.ip;
     }
+    case RouteParamtypes.CUSTOM: {
+      return await args.handler!(ctx, data);
+    }
     default:
       return;
   }

--- a/src/decorators/controller.decorator.ts
+++ b/src/decorators/controller.decorator.ts
@@ -1,9 +1,9 @@
 // deno-lint-ignore-file no-explicit-any
-import { Reflect, Router, RouterContext, helpers } from "../deps.ts";
+import { Reflect, Router, RouterContext, helpers } from '../deps.ts';
 
-import { ActionMetadata, RouteArgsMetadata } from "../interfaces/mod.ts";
-import { RouteParamtypes } from "../enums/mod.ts";
-import { METHOD_METADATA, ROUTE_ARGS_METADATA } from "../const.ts";
+import { ActionMetadata, RouteArgsMetadata } from '../interfaces/mod.ts';
+import { RouteParamtypes } from '../enums/mod.ts';
+import { METHOD_METADATA, ROUTE_ARGS_METADATA } from '../const.ts';
 
 type Next = () => Promise<unknown>;
 
@@ -16,8 +16,8 @@ export function Controller<T extends { new (...instance: any[]): Object }>(
       private _route?: Router;
 
       init(routePrefix?: string) {
-        const prefix = routePrefix ? `/${routePrefix}` : "";
-        this._path = prefix + (path ? `/${path}` : "");
+        const prefix = routePrefix ? `/${routePrefix}` : '';
+        this._path = prefix + (path ? `/${path}` : '');
         const route = new Router();
         const list: ActionMetadata[] =
           Reflect.getMetadata(METHOD_METADATA, fn.prototype) || [];
@@ -44,7 +44,7 @@ export function Controller<T extends { new (...instance: any[]): Object }>(
             }
           );
 
-          const fullPath = this.path + (meta.path ? `/${meta.path}` : "");
+          const fullPath = this.path + (meta.path ? `/${meta.path}` : '');
           console.log(`Mapped: [${meta.method.toUpperCase()}]${fullPath}`);
         });
 
@@ -71,6 +71,9 @@ async function getContextData(
   const res = ctx.response;
 
   switch (paramtype) {
+    case RouteParamtypes.CONTEXT: {
+      return ctx;
+    }
     case RouteParamtypes.REQUEST: {
       return req;
     }

--- a/src/decorators/controller.decorator.ts
+++ b/src/decorators/controller.decorator.ts
@@ -3,7 +3,11 @@ import { Reflect, Router, RouterContext, helpers } from '../deps.ts';
 
 import { ActionMetadata, RouteArgsMetadata } from '../interfaces/mod.ts';
 import { RouteParamtypes } from '../enums/mod.ts';
-import { METHOD_METADATA, ROUTE_ARGS_METADATA } from '../const.ts';
+import {
+  METHOD_METADATA,
+  MIDDLEWARE_METADATA,
+  ROUTE_ARGS_METADATA,
+} from '../const.ts';
 
 type Next = () => Promise<unknown>;
 
@@ -30,8 +34,20 @@ export function Controller<T extends { new (...instance: any[]): Object }>(
               meta.functionName
             ) || [];
 
+          const middlewaresMetadata = Reflect.getMetadata(
+            MIDDLEWARE_METADATA,
+            fn.prototype,
+            meta.functionName
+          );
+          const middlewares = Array.isArray(middlewaresMetadata)
+            ? middlewaresMetadata
+            : middlewaresMetadata
+            ? [middlewaresMetadata]
+            : [];
+
           (route as any)[meta.method](
             `/${meta.path}`,
+            ...middlewares,
             async (context: RouterContext<string>, next: Next) => {
               const inputs = await Promise.all(
                 argsMetadataList

--- a/src/decorators/http-methods.decorator.ts
+++ b/src/decorators/http-methods.decorator.ts
@@ -1,15 +1,16 @@
-import { Reflect } from "../deps.ts";
-import { ActionMetadata, HTTPMethods } from "../interfaces/mod.ts";
-import { METHOD_METADATA } from "../const.ts";
+import { Reflect } from '../deps.ts';
+import { ActionMetadata, HTTPMethods } from '../interfaces/mod.ts';
+import { METHOD_METADATA } from '../const.ts';
 
-export const Get = mappingMethod("get");
-export const Post = mappingMethod("post");
-export const Put = mappingMethod("put");
-export const Patch = mappingMethod("patch");
-export const Delete = mappingMethod("delete");
+export const Get = mappingMethod('get');
+export const Post = mappingMethod('post');
+export const Put = mappingMethod('put');
+export const Patch = mappingMethod('patch');
+export const Delete = mappingMethod('delete');
+export const All = mappingMethod('all');
 
 function mappingMethod(method: HTTPMethods) {
-  return (path = "") =>
+  return (path = '') =>
     (target: unknown, functionName: string, _: PropertyDescriptor) => {
       const meta: ActionMetadata = { path, method, functionName };
       addMetadata(meta, target, METHOD_METADATA);

--- a/src/decorators/injectable.ts
+++ b/src/decorators/injectable.ts
@@ -1,0 +1,27 @@
+import { Reflect } from '../deps.ts';
+
+import { InjectionOptions } from 'https://deno.land/x/inject@v0.1.2/decorators.ts';
+import { Injectable as OriginalInjectable } from 'https://deno.land/x/inject@v0.1.2/mod.ts';
+import { INJECTOR_INTERFACES_METADATA } from '../const.ts';
+
+export function Injectable({
+  implementing = [],
+  ...originalOptions
+}: {
+  implementing?: string | string[];
+} & InjectionOptions = {}): ClassDecorator {
+  const implementings = Array.isArray(implementing)
+    ? implementing
+    : [implementing];
+
+  return (target: any) => {
+    if (implementings.length > 0) {
+      Reflect.defineMetadata(
+        INJECTOR_INTERFACES_METADATA,
+        implementings,
+        target
+      );
+    }
+    return OriginalInjectable({ ...originalOptions })(target);
+  };
+}

--- a/src/decorators/injectable.ts
+++ b/src/decorators/injectable.ts
@@ -8,7 +8,7 @@ export function Injectable({
   implementing = [],
   ...originalOptions
 }: {
-  implementing?: string | string[];
+  implementing?: string | symbol | string[] | symbol[];
 } & InjectionOptions = {}): ClassDecorator {
   const implementings = Array.isArray(implementing)
     ? implementing

--- a/src/decorators/module.decorator.ts
+++ b/src/decorators/module.decorator.ts
@@ -1,11 +1,12 @@
-import { Reflect } from "../deps.ts";
-import { CreateRouterOption } from "../interfaces/mod.ts";
-import { MODULE_METADATA } from "../const.ts";
+import { Reflect } from '../deps.ts';
+import { CreateRouterOption } from '../interfaces/mod.ts';
+import { MODULE_METADATA } from '../const.ts';
+import { ClassConstructor } from '../types.ts';
 
-export function Module<T extends { new (...instance: unknown[]): Object }>(
+export function Module<T>(
   data: CreateRouterOption
-) {
-  return (fn: T): void => {
-    Reflect.defineMetadata(MODULE_METADATA, data, fn.prototype);
+): (target: ClassConstructor<T>) => void {
+  return (target: ClassConstructor<T>) => {
+    Reflect.defineMetadata(MODULE_METADATA, data, target.prototype);
   };
 }

--- a/src/decorators/route-params.decorator.ts
+++ b/src/decorators/route-params.decorator.ts
@@ -1,10 +1,10 @@
-import { Reflect } from "../deps.ts";
-import { RouteParamtypes } from "../enums/mod.ts";
-import { ROUTE_ARGS_METADATA } from "../const.ts";
-import { RouteArgsMetadata, ParamData } from "../interfaces/mod.ts";
+import { Reflect } from '../deps.ts';
+import { RouteParamtypes } from '../enums/mod.ts';
+import { ROUTE_ARGS_METADATA } from '../const.ts';
+import { RouteArgsMetadata, ParamData } from '../interfaces/mod.ts';
 
-const isUndefined = (obj: any): obj is undefined => typeof obj === "undefined";
-const isString = (fn: any): fn is string => typeof fn === "string";
+const isUndefined = (obj: any): obj is undefined => typeof obj === 'undefined';
+const isString = (fn: any): fn is string => typeof fn === 'string';
 const isNil = (obj: any): obj is null | undefined =>
   isUndefined(obj) || obj === null;
 
@@ -28,6 +28,10 @@ function createPipesRouteParamDecorator(paramtype: RouteParamtypes) {
 
 export function Request(property?: string): ParameterDecorator {
   return createPipesRouteParamDecorator(RouteParamtypes.REQUEST)(property);
+}
+
+export function Context(property?: string): ParameterDecorator {
+  return createPipesRouteParamDecorator(RouteParamtypes.CONTEXT)(property);
 }
 
 export function Response(property?: string): ParameterDecorator {

--- a/src/decorators/route-params.decorator.ts
+++ b/src/decorators/route-params.decorator.ts
@@ -1,12 +1,8 @@
-import { Reflect } from '../deps.ts';
-import { RouteParamtypes } from '../enums/mod.ts';
-import { ROUTE_ARGS_METADATA } from '../const.ts';
-import { RouteArgsMetadata, ParamData } from '../interfaces/mod.ts';
-
-const isUndefined = (obj: any): obj is undefined => typeof obj === 'undefined';
-const isString = (fn: any): fn is string => typeof fn === 'string';
-const isNil = (obj: any): obj is null | undefined =>
-  isUndefined(obj) || obj === null;
+import { ROUTE_ARGS_METADATA } from "../const.ts";
+import { Reflect } from "../deps.ts";
+import { RouteParamtypes } from "../enums/mod.ts";
+import { ParamData, RouteArgsMetadata } from "../interfaces/mod.ts";
+import { isNil, isString } from "../utils/router.util.ts";
 
 function createPipesRouteParamDecorator(paramtype: RouteParamtypes) {
   return (data?: ParamData): ParameterDecorator =>

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -8,7 +8,7 @@ import {
 export { Application, Router, helpers };
 export type { RouterContext };
 
-export { Reflect } from "https://deno.land/x/reflect_metadata@v0.1.12-2/mod.ts";
+export { Reflect } from "https://deno.land/x/deno_reflect@v0.2.1/mod.ts";
 
 export {
   bootstrap,

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -3,7 +3,7 @@ import {
   Router,
   RouterContext,
   helpers,
-} from "https://deno.land/x/oak@v10.1.0/mod.ts";
+} from "https://deno.land/x/oak@12.6.1/mod.ts";
 
 export { Application, Router, helpers };
 export type { RouterContext };

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -3,7 +3,7 @@ import {
   Router,
   RouterContext,
   helpers,
-} from "https://deno.land/x/oak@12.6.1/mod.ts";
+} from "https://deno.land/x/oak@v12.6.1/mod.ts";
 
 export { Application, Router, helpers };
 export type { RouterContext };

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -3,14 +3,12 @@ import {
   Router,
   RouterContext,
   helpers,
-} from "https://deno.land/x/oak@v12.6.2/mod.ts";
+} from 'https://deno.land/x/oak@v12.6.2/mod.ts';
 
 export { Application, Router, helpers };
 export type { RouterContext };
 
-export { Reflect } from "https://deno.land/x/deno_reflect@v0.2.1/mod.ts";
+export { Reflect } from 'https://deno.land/x/deno_reflect@v0.2.1/mod.ts';
 
-export {
-  bootstrap,
-  Injectable,
-} from "https://deno.land/x/inject@v0.1.2/mod.ts";
+export { bootstrap } from 'https://deno.land/x/inject@v0.1.2/mod.ts';
+export { Injectable } from './decorators/injectable.ts';

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -3,7 +3,7 @@ import {
   Router,
   RouterContext,
   helpers,
-} from "https://deno.land/x/oak@v12.6.1/mod.ts";
+} from "https://deno.land/x/oak@v12.6.2/mod.ts";
 
 export { Application, Router, helpers };
 export type { RouterContext };

--- a/src/enums/route-paramtypes.enum.ts
+++ b/src/enums/route-paramtypes.enum.ts
@@ -1,5 +1,6 @@
 export enum RouteParamtypes {
   REQUEST,
+  CONTEXT,
   RESPONSE,
   NEXT,
   BODY,

--- a/src/enums/route-paramtypes.enum.ts
+++ b/src/enums/route-paramtypes.enum.ts
@@ -12,4 +12,5 @@ export enum RouteParamtypes {
   FILES,
   HOST,
   IP,
+  CUSTOM,
 }

--- a/src/interfaces/action-metadata.interface.ts
+++ b/src/interfaces/action-metadata.interface.ts
@@ -1,4 +1,4 @@
-export type HTTPMethods = "get" | "put" | "patch" | "post" | "delete";
+export type HTTPMethods = 'get' | 'put' | 'patch' | 'post' | 'delete' | 'all';
 
 export interface ActionMetadata {
   path: string;

--- a/src/interfaces/create-router-option.interface.ts
+++ b/src/interfaces/create-router-option.interface.ts
@@ -1,6 +1,8 @@
+import { ClassConstructor } from '../types.ts';
+
 export interface CreateRouterOption {
-  controllers: any[];
-  providers?: any[];
-  modules?: any[];
+  controllers: ClassConstructor[];
+  providers?: ClassConstructor[];
+  modules?: ClassConstructor[];
   routePrefix?: string;
 }

--- a/src/interfaces/route-args-metadata.interface.ts
+++ b/src/interfaces/route-args-metadata.interface.ts
@@ -1,3 +1,4 @@
+import { RouterContext } from "../deps.ts";
 import { RouteParamtypes } from "../enums/mod.ts";
 export type ParamData = Record<string, unknown> | string | number;
 
@@ -5,4 +6,5 @@ export interface RouteArgsMetadata {
   paramtype: RouteParamtypes;
   index: number;
   data?: ParamData;
+  handler?: (ctx: RouterContext<string>, data?: ParamData) => any;
 }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,3 +1,4 @@
-export { Injectable } from './deps.ts';
-export * from './decorators/mod.ts';
-export * from './utils/router.util.ts';
+export { Injectable } from "./deps.ts";
+export * from "./decorators/mod.ts";
+export * from "./utils/router.util.ts";
+export { setLogger } from "./utils/logger.ts";

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,4 +1,3 @@
 export { Injectable } from './deps.ts';
 export * from './decorators/mod.ts';
 export * from './utils/router.util.ts';
-export { MIDDLEWARE_METADATA } from './const.ts';

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,3 +1,4 @@
-export { Injectable } from "./deps.ts";
-export * from "./decorators/mod.ts";
-export * from "./utils/router.util.ts";
+export { Injectable } from './deps.ts';
+export * from './decorators/mod.ts';
+export * from './utils/router.util.ts';
+export { MIDDLEWARE_METADATA } from './const.ts';

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,4 +1,8 @@
 export { Injectable } from "./deps.ts";
 export * from "./decorators/mod.ts";
-export * from "./utils/router.util.ts";
+export {
+  assignModule,
+  registerCustomRouteParamDecorator,
+  registerMiddlewareMethodDecorator,
+} from "./utils/router.util.ts";
 export { setLogger } from "./utils/logger.ts";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,2 @@
+//deno-lint-ignore no-explicit-any
+export type ClassConstructor<T = object> = new (...args: any[]) => T;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,35 @@
+// Logger interface
+type Logger = {
+  debug: (...args: unknown[]) => void;
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+  trace: (...args: unknown[]) => void;
+};
+
+// Logger variable, initially null
+let logger: Logger | null = null;
+
+// Function to set the logger
+export function setLogger(newLogger: Logger): void {
+  logger = newLogger;
+}
+
+// Proxy handler
+const handler: ProxyHandler<{}> = {
+  get(_target, prop, _receiver) {
+    if (logger && typeof prop === "string" && prop in logger) {
+      return (...args: unknown[]) => {
+        // Call the corresponding method on the logger if it exists
+        (logger as Logger)[prop as keyof Logger](...args);
+      };
+    }
+    // Default behavior for methods not in logger
+    return () => {};
+  },
+};
+
+// Create the Proxy
+const defaultExport = new Proxy({}, handler);
+
+export default defaultExport as Logger;

--- a/src/utils/router.util.ts
+++ b/src/utils/router.util.ts
@@ -1,7 +1,8 @@
-import { Reflect, Router, bootstrap } from "../deps.ts";
+import { Reflect, Router, bootstrap } from '../deps.ts';
 
-import { MODULE_METADATA } from "../const.ts";
-import { CreateRouterOption } from "../interfaces/mod.ts";
+import { MIDDLEWARE_METADATA, MODULE_METADATA } from '../const.ts';
+import { CreateRouterOption } from '../interfaces/mod.ts';
+import { RouterContext, Next } from 'oak';
 
 const createRouter = (
   { controllers, providers, routePrefix }: CreateRouterOption,
@@ -9,10 +10,10 @@ const createRouter = (
   router = new Router()
 ) => {
   controllers.forEach((Controller) => {
-    Reflect.defineMetadata("design:paramtypes", providers, Controller);
+    Reflect.defineMetadata('design:paramtypes', providers, Controller);
     const controller = bootstrap<any>(Controller);
     const prefixFull = prefix
-      ? prefix + (routePrefix ? `/${routePrefix}` : "")
+      ? prefix + (routePrefix ? `/${routePrefix}` : '')
       : routePrefix;
     controller.init(prefixFull);
     const path = controller.path;
@@ -40,4 +41,24 @@ const getRouter = (module: any, prefix?: string, router?: Router) => {
 export const assignModule = (module: any) => {
   const router = getRouter(module);
   return router.routes();
+};
+
+/**
+ * Registers a decorator that can be added to a controller's
+ * method. The handler will be called at runtime when the
+ * endpoint method is invoked with the Context and Next parameters.
+ *
+ * @param target decorator's target
+ * @param methodName decorator's method name
+ * @param handler decorator's handler
+ */
+export const registerMiddlewareMethodDecorator = (
+  target: any,
+  methodName: Function,
+  handler: (ctx: RouterContext, next: Next) => void
+) => {
+  const middleware =
+    Reflect.getMetadata(MIDDLEWARE_METADATA, target, methodName) || [];
+  middleware.push(handler);
+  Reflect.defineMetadata(MIDDLEWARE_METADATA, middleware, target, methodName);
 };

--- a/src/utils/router.util.ts
+++ b/src/utils/router.util.ts
@@ -3,6 +3,17 @@ import { Reflect, Router, bootstrap } from '../deps.ts';
 import { MIDDLEWARE_METADATA, MODULE_METADATA } from '../const.ts';
 import { CreateRouterOption } from '../interfaces/mod.ts';
 import { RouterContext, Next } from 'oak';
+import { ParamData } from '../interfaces/mod.ts';
+import { RouteArgsMetadata } from '../interfaces/mod.ts';
+import { ROUTE_ARGS_METADATA } from '../const.ts';
+import { RouteParamtypes } from '../enums/mod.ts';
+import { ClassConstructor } from '../types.ts';
+
+export const isUndefined = (obj: any): obj is undefined =>
+  typeof obj === 'undefined';
+export const isString = (fn: any): fn is string => typeof fn === 'string';
+export const isNil = (obj: any): obj is null | undefined =>
+  isUndefined(obj) || obj === null;
 
 const createRouter = (
   { controllers, providers, routePrefix }: CreateRouterOption,
@@ -53,7 +64,7 @@ export const assignModule = (module: any) => {
  * @param handler decorator's handler
  */
 export const registerMiddlewareMethodDecorator = (
-  target: any,
+  target: ClassConstructor,
   methodName: string,
   handler: (ctx: RouterContext, next: Next) => void
 ) => {
@@ -61,4 +72,35 @@ export const registerMiddlewareMethodDecorator = (
     Reflect.getMetadata(MIDDLEWARE_METADATA, target, methodName) || [];
   middleware.push(handler);
   Reflect.defineMetadata(MIDDLEWARE_METADATA, middleware, target, methodName);
+};
+
+/**
+ * Registers a custom route parameter decorator.
+ *
+ * @param {ClassConstructor} target - the target object
+ * @param {string} methodName - the name of the method
+ * @param {number} paramIndex - the index of the parameter
+ * @return {(data?: ParamData) => (handler: (ctx: RouterContext<string>) => void) => void} a function that takes optional data and returns a function that requires the param's handler as only parameter
+ */
+export const registerCustomRouteParamDecorator = (
+  target: ClassConstructor,
+  methodName: string,
+  paramIndex: number
+) => {
+  return (data?: ParamData) =>
+    (handler: (ctx: RouterContext<string>) => void) => {
+      const args: RouteArgsMetadata[] =
+        Reflect.getMetadata(ROUTE_ARGS_METADATA, target, methodName) || [];
+      const hasParamData = isNil(data) || isString(data);
+      const paramData = hasParamData ? data : undefined;
+
+      args.push({
+        paramtype: RouteParamtypes.CUSTOM,
+        index: paramIndex,
+        data: paramData,
+        handler,
+      });
+
+      Reflect.defineMetadata(ROUTE_ARGS_METADATA, args, target, methodName);
+    };
 };

--- a/src/utils/router.util.ts
+++ b/src/utils/router.util.ts
@@ -54,7 +54,7 @@ export const assignModule = (module: any) => {
  */
 export const registerMiddlewareMethodDecorator = (
   target: any,
-  methodName: Function,
+  methodName: string,
   handler: (ctx: RouterContext, next: Next) => void
 ) => {
   const middleware =


### PR DESCRIPTION
Hey, I found this good project, it looked like it wasn't very active, possibly because the dependency with reflect_metadata was preventing it from working at all, at least in recent versions of Deno.

While I was at it I updated the documentation and added the ability to declare custom decorators. 

Using it in production (importing it from github for the time being).

Hope this is helpful.

